### PR TITLE
Motion: Förenkla styrelse- och utskottsarbetet

### DIFF
--- a/stadgar.md
+++ b/stadgar.md
@@ -284,9 +284,9 @@ Utbildningsutskottet, med ansvar för föreningensprogram.
 
 Dalophest, med ansvar för att främja gemenskapen inom föreningen.
 
-Ordförande av utskotten väljs av årsmötet. Ordförande skall sitta i
+Ordförande av utskotten utses av styrelsen. Ordförande skall sitta i
 styrelsen i form av adjungerad ledamot om denna ej redan håller en plats
-i styrelsen. Resterande medlemmar av utskottet tillsätts av styrelsen.
+i styrelsen. Resterande medlemmar av utskottet tillsätts av utskottets ordförande.
 
 Utskotten skall rapportera till styrelsen vid varje styrelsemöte.
 

--- a/stadgar.md
+++ b/stadgar.md
@@ -245,8 +245,6 @@ förslagsrätt.
 
 **Kallelse beslutsmässighet och omröstning:**
 
-Kallelse skall ske 2-3 veckor innan styrelsemöte.
-
 Styrelsen sammanträder regelbundet, eller på kallelse av ordförande,
 eller genom ordföranden av i styrelsen sittande medlemmar.
 


### PR DESCRIPTION
Av Gustav Kånåhols

# Motivering

Utskotten är en viktigt del av föreningens verksamhet. Det är via dem som föreningen främjar de
målen som står beskrivna i värdegrunden. I nuläget måste ordförande för respektive utskott
väljas in på ett årsmöte. Skulle en ordförande av ett utskott avgå eller behöva avsättas måste
alltså ett extrainsatt årsmöte hållas för att tillsätta en ersättare.

För att ett styrelsemöte skall vara giltigt bör det följa stadgarna, i nuläget görs det svårare på
grund av hur stadgarna är formulerade. Hur styrelsen bedriver sina möten bör inte dikteras av
stadgarna på den nivån.

# Förslag till beslut
- att ändra i stadgarna som rör tillsättning av ordförande av utskotten under rubriken “Utskott” till att lyda: “Ordförande av utskotten utses av styrelsen. Ordförande skall sitta i styrelsen i form av adjungerad ledamot om denna ej redan håller en plats i styrelsen. Resterande medlemmar av utskottet tillsätts av utskottets ordförande.”

- att ta bort paragrafen under “Kallelse beslutsmässighet och omröstning” som lyder: “Kallelse skall ske 2-3 veckor innan styrelsemöte.”