### PR TITLE
Motion: Flytta årsmötet till hösten

### DIFF
--- a/stadgar.md
+++ b/stadgar.md
@@ -88,8 +88,8 @@ Föreningens firma tecknas av ordförande och kassör.
 
 **Verksamhets- och räkenskapsår:**
 
-Föreningens verksamhets- och räkenskapsår omfattar tiden 1 januari till
-och med 31 december.
+Föreningens verksamhets- och räkenskapsår omfattar tiden 1 juli till
+och med 30 juni.
 
 Styrelsen är vald för tiden från årsmötet till och med årsmötet
 påföljande år.


### PR DESCRIPTION
Av Gustav Kånåhols, Fredrik Nygårds och Johan Sandred

# Motivering
Det har varit svårt att hålla engagemanget uppe efter Rookieperioden eftersom generaler, faddrar och styrelsen har behövt återhämta sig. Jag anser därför att vi bör möjliggöra för att få nya studenter att engagera sig i styrelsearbetet och eventen. Därför föreslår vi att flytta årsmötet till höstterminen. Detta löser även problemet med att studenter som går tredje året har dåligt med tid eftersom kurserna kräver mer tid.

I och med förändringen anser jag att det försvårar arbetet inför årsmötet eftersom föregående verksamhetsår avslutas över nio månader före mötet, istället för två. Vi vill därför flytta verksamhetsåret till att avslutas under sommaren. Detta betyder att både Rookieperioden och dess äskning kommer att vara under samma verksamhetsår.

# Förslag till beslut
- att istället ha årsmötet i oktober och därav ändra stadgarna under ÅRSMÖTE OCH EXTRA ÅRSMÖTE Tidpunkt och kallelse så att de reflekterar det beslutet.

- att ändra Datalogi Föreningens stadgar under MÅL OCH INRIKTNING Verksamhets- och räkenskapsår till att lyda: Föreningens verksamhets- och räkenskapsår omfattar tiden 1 juli till och med 30 juni. Styrelsen är vald för tiden från årsmötet till och med årsmötet påföljande år.
  Samt att det kommande verksamhetsåret avslutas 30 juni.